### PR TITLE
Fix Java 8 support

### DIFF
--- a/src/main/java/com/starkbank/ellipticcurve/Curve.java
+++ b/src/main/java/com/starkbank/ellipticcurve/Curve.java
@@ -120,7 +120,7 @@ public class Curve {
             return false;
         }
         // y^2 - (x^3 + A*x + B) mod P == 0
-        BigInteger lhs = p.y.modPow(BigInteger.TWO, this.P);
+        BigInteger lhs = p.y.modPow(BigInteger.valueOf(2), this.P);
         BigInteger rhs = p.x.modPow(BigInteger.valueOf(3), this.P)
                 .add(this.A.multiply(p.x))
                 .add(this.B)
@@ -148,7 +148,7 @@ public class Curve {
                 .add(this.B)
                 .mod(this.P);
         BigInteger y = Math.modularSquareRoot(ySquared, this.P);
-        if (isEven != y.mod(BigInteger.TWO).equals(BigInteger.ZERO)) {
+        if (isEven != y.mod(BigInteger.valueOf(2)).equals(BigInteger.ZERO)) {
             y = this.P.subtract(y);
         }
         return y;

--- a/src/main/java/com/starkbank/ellipticcurve/PublicKey.java
+++ b/src/main/java/com/starkbank/ellipticcurve/PublicKey.java
@@ -70,7 +70,7 @@ public class PublicKey {
      */
     public String toCompressed() {
         int baseLength = 2 * curve.length();
-        String parityTag = point.y.mod(BigInteger.TWO).equals(BigInteger.ZERO) ? EVEN_TAG : ODD_TAG;
+        String parityTag = point.y.mod(BigInteger.valueOf(2)).equals(BigInteger.ZERO) ? EVEN_TAG : ODD_TAG;
         String xHex = leftPad(point.x.toString(16), baseLength);
         return parityTag + xHex;
     }

--- a/src/test/java/com/starkbank/ellipticcurve/SecurityTest.java
+++ b/src/test/java/com/starkbank/ellipticcurve/SecurityTest.java
@@ -422,7 +422,7 @@ public class SecurityTest {
             BigInteger P = BigInteger.valueOf(17);
             for (int value = 1; value < 17; value++) {
                 BigInteger val = BigInteger.valueOf(value);
-                BigInteger halfP = P.subtract(BigInteger.ONE).divide(BigInteger.TWO);
+                BigInteger halfP = P.subtract(BigInteger.ONE).divide(BigInteger.valueOf(2));
                 if (val.modPow(halfP, P).equals(BigInteger.ONE)) {
                     BigInteger root = Math.modularSquareRoot(val, P);
                     assertEquals(val, root.multiply(root).mod(P));
@@ -436,7 +436,7 @@ public class SecurityTest {
             BigInteger P = BigInteger.valueOf(13);
             for (int value = 1; value < 13; value++) {
                 BigInteger val = BigInteger.valueOf(value);
-                BigInteger halfP = P.subtract(BigInteger.ONE).divide(BigInteger.TWO);
+                BigInteger halfP = P.subtract(BigInteger.ONE).divide(BigInteger.valueOf(2));
                 if (val.modPow(halfP, P).equals(BigInteger.ONE)) {
                     BigInteger root = Math.modularSquareRoot(val, P);
                     assertEquals(val, root.multiply(root).mod(P));
@@ -450,7 +450,7 @@ public class SecurityTest {
             BigInteger P = BigInteger.valueOf(7);
             for (int value = 1; value < 7; value++) {
                 BigInteger val = BigInteger.valueOf(value);
-                BigInteger halfP = P.subtract(BigInteger.ONE).divide(BigInteger.TWO);
+                BigInteger halfP = P.subtract(BigInteger.ONE).divide(BigInteger.valueOf(2));
                 if (val.modPow(halfP, P).equals(BigInteger.ONE)) {
                     BigInteger root = Math.modularSquareRoot(val, P);
                     assertEquals(val, root.multiply(root).mod(P));


### PR DESCRIPTION
Source of regression 09f83f2

`BigInteger.TWO` is only available on Java 9+.
It is private in Jdk8, causing an exception during runtime.